### PR TITLE
Disable `truncate_string` behaviour unless db is MySQL

### DIFF
--- a/lib/active_record/validations/adapter_helper.rb
+++ b/lib/active_record/validations/adapter_helper.rb
@@ -1,0 +1,9 @@
+module ActiveRecord
+  module Validations
+    module AdapterHelper
+      def mysql_adapter?(connection)
+        connection.is_a?(ConnectionAdapters::AbstractMysqlAdapter)
+      end
+    end
+  end
+end

--- a/lib/active_record/validations/database_constraints.rb
+++ b/lib/active_record/validations/database_constraints.rb
@@ -1,9 +1,12 @@
 require 'active_model/validations/bytesize'
 require 'active_model/validations/not_null'
+require 'active_record/validations/adapter_helper'
 
 module ActiveRecord
   module Validations
     class DatabaseConstraintsValidator < ActiveModel::EachValidator
+      include Validations::AdapterHelper
+
       attr_reader :constraints
 
       VALID_CONSTRAINTS = Set[:size, :not_null, :range]
@@ -35,7 +38,7 @@ module ActiveRecord
 
       def size_validator(klass, column)
         return unless constraints.include?(:size)
-        return unless mysql_adapter?(klass)
+        return unless mysql_adapter?(klass.connection)
         return unless column.text? || column.binary?
 
         maximum, type, encoding = ActiveRecord::DatabaseValidations::MySQL.column_size_limit(column)
@@ -48,7 +51,7 @@ module ActiveRecord
 
       def range_validator(klass, column)
         return unless constraints.include?(:range)
-        return unless mysql_adapter?(klass)
+        return unless mysql_adapter?(klass.connection)
         return unless column.number?
 
         args = { attributes: [column.name.to_sym], class: klass, allow_nil: true }
@@ -78,12 +81,6 @@ module ActiveRecord
         attribute_validators(record.class, attribute).each do |validator|
           validator.validate(record)
         end
-      end
-
-      private
-
-      def mysql_adapter?(klass)
-        klass.connection.class < ::ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter
       end
     end
   end

--- a/lib/active_record/validations/string_truncator.rb
+++ b/lib/active_record/validations/string_truncator.rb
@@ -4,6 +4,7 @@ module ActiveRecord
       extend ActiveSupport::Concern
 
       def truncate_value_to_field_limit(field, value)
+        return value unless mysql_adapter?
         return if value.nil?
 
         column = self.class.columns_hash[field.to_s]
@@ -18,6 +19,12 @@ module ActiveRecord
         end
 
         value
+      end
+
+      private
+
+      def mysql_adapter?
+        self.class.connection.class < ::ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter
       end
 
       module ClassMethods

--- a/lib/active_record/validations/string_truncator.rb
+++ b/lib/active_record/validations/string_truncator.rb
@@ -1,10 +1,13 @@
+require 'active_record/validations/adapter_helper'
+
 module ActiveRecord
   module DatabaseValidations
     module StringTruncator
       extend ActiveSupport::Concern
+      include Validations::AdapterHelper
 
       def truncate_value_to_field_limit(field, value)
-        return value unless mysql_adapter?
+        return value unless mysql_adapter?(self.class.connection)
         return if value.nil?
 
         column = self.class.columns_hash[field.to_s]
@@ -19,12 +22,6 @@ module ActiveRecord
         end
 
         value
-      end
-
-      private
-
-      def mysql_adapter?
-        self.class.connection.class < ::ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter
       end
 
       module ClassMethods


### PR DESCRIPTION
Related to https://github.com/Shopify/activerecord-databasevalidations/pull/6

It also doesn't make sense to run `truncate_string` on other db adapters since the implementation is compatible for only the MySQL adapter at the moment. 